### PR TITLE
Fix Track object generation

### DIFF
--- a/src/qobuz/track.py
+++ b/src/qobuz/track.py
@@ -46,12 +46,8 @@ class Track(object):
         self._performer_id = track_item.get("performer", {}).get("id")
         self._artist = None
 
-        maximum_bit_depth = track_item.get("album", {}).get(
-            "maximum_bit_depth"
-        )
-        maximum_sampling_rate = track_item.get("album", {}).get(
-            "maximum_sampling_rate"
-        )
+        maximum_bit_depth = track_item.get("maximum_bit_depth", 0)
+        maximum_sampling_rate = track_item.get("maximum_sampling_rate", 0)
         if maximum_bit_depth < 24:
             self.maximum_format_id = audio_format["flac"]
         elif maximum_sampling_rate <= 96:


### PR DESCRIPTION
It seems the API response for the album request has changed, and it's making the `Track` constructor fail.

The attributes `maximum_bit_depth` and `maximum_sampling_rate` are now directly included in the first level in the track item, instead of inside `album`.
